### PR TITLE
fix: use u32 instead of I32 for the vote function

### DIFF
--- a/contract/assembly/index.ts
+++ b/contract/assembly/index.ts
@@ -17,22 +17,23 @@ export function getPolls(): Poll[] {
     return listedPolls.values();
 }
 
-export function vote(pollId: string, contestantIndex: string): void {
 
+export function vote(pollId: string, contestantIndex: string): void {
     let poll = listedPolls.get(pollId);
     if(poll == null) {
         throw new Error(`poll with ${pollId} doesnt exists`);
     }
     if(poll.participants.includes(context.sender)) {
         throw new Error(`user  ${context.sender} has already voted`);
-
     }
     // if(new Date(context.blockTimestamp).getTime() > new Date(U64.parseInt(poll.deadline)).getTime()) {
     //     throw new Error(`poll with id ${pollId} is expired ${context.blockTimestamp } ${U64.parseInt(poll.deadline)}`);
     // }
-   
-    poll.vote(I32.parseInt(contestantIndex));
+    const index: u32 = U32.parseInt(contestantIndex);
+    poll.vote(index);
     poll.participants.push(context.sender);
     listedPolls.set(pollId, poll);
 }
+
+
 

--- a/contract/assembly/model.ts
+++ b/contract/assembly/model.ts
@@ -41,7 +41,7 @@ export class Poll {
     poll.owner = context.sender;
     return poll;
   }
-  public vote(contestantIndex: i32): void {
+  public vote(contestantIndex: u32): void {
     let contestant = this.contestants[contestantIndex];
     if(contestant === null) {
       throw new Error(`contestant with ${contestantIndex} doesnt exists`);


### PR DESCRIPTION

u32 is 32 bit unsigned integer i.e. no negative values, unsigned integers are often used in smart contracts to avoid overflow, an unsigned integer has more range than a signed integer.

An I32 is  btwn -2147483648 to 2147483647 and an unsigned integer is between 0 to 4294967295

the PR also contains type conversion from string to U32 